### PR TITLE
add example of stateful hypothesis testing

### DIFF
--- a/hypothesis_auto/fsm.py
+++ b/hypothesis_auto/fsm.py
@@ -8,18 +8,34 @@ class State(ABC):
         pass
 
     @abstractmethod
-    def next(self, condition):
+    def next(self, condition) -> "State":
         pass
 
 
 class StateMachine(ABC):
-    def __init__(self, initialState: State, initialCondition) -> None:
-        self.state = initialState
-        self.condition = initialCondition
+    def __init__(self, initial_state: State, initial_condition) -> None:
+        self._state = initial_state
+        self.condition = initial_condition
 
-    @abstractmethod
-    def run(self) -> None:
-        self.state.run()
-        while True:
-            self.state.next(self.condition)
-            self.state.run()
+    def run(self, conditions) -> None:
+        for cond in conditions:
+            self.step(cond)
+            if self.stop_predicate():
+                return
+
+    def step(self, condition):
+        self.condition = condition
+        self.state = self._state.next(self.condition)
+
+    @property
+    def state(self):
+        return self._state
+
+    @state.setter
+    def state(self, value: State):
+        self._state = value
+        self._state.run()
+
+    def stop_predicate(self):
+        """State machine will run until this function returns True"""
+        return False

--- a/tests/test_statefulness.py
+++ b/tests/test_statefulness.py
@@ -1,6 +1,52 @@
-from hypothesis_auto import *
-from hypothesis.stateful import run_state_machine_as_test
+import hypothesis.strategies as st
+import pytest
+from hypothesis import given
+from hypothesis.stateful import (Bundle, RuleBasedStateMachine, consumes,
+                                 invariant, multiple, precondition, rule)
+
+from hypothesis_auto import (FirstGear, GearState, Neutral, SecondGear,
+                             ThirdGear, TransmissionSystem)
 
 
-def test_rule_based_state_machine():
-    run_state_machine_as_test(TransmissionSystem)
+class AutoFSMTest(RuleBasedStateMachine):
+    def __init__(self):
+        super().__init__()
+        self.auto = TransmissionSystem()
+
+    rpms = Bundle('rpms')
+    rpm_sets = Bundle('rpm_sets')
+
+    @rule(target=rpms, rpm=st.integers(min_value=0))
+    def add_rpm(self, rpm):
+        return rpm
+
+    @rule(target=rpm_sets, rpms=st.lists(st.integers(min_value=0)))
+    def add_rpms(self, rpms):
+        return rpms
+
+    ## These methods exercise the step and run methods of
+    ## TransmissionSystem, as possible intervening actions between
+    ## test assertions
+    @rule(rpm=consumes(rpms))
+    def step(self, rpm):
+        self.auto.step(rpm)
+
+    @rule(rpms=consumes(rpm_sets))
+    def run(self, rpms):
+        self.auto.run(rpms)
+
+
+    # These are the test methods that assert facts about the state machine
+    @invariant()
+    def state_is_always_a_gear_state(self):
+        assert isinstance(self.auto.state, GearState)
+
+    @precondition(lambda self: isinstance(self.auto.state, Neutral))
+    @rule(rpm=consumes(rpms))
+    def step_from_neutral_must_be_neutral_or_first(self, rpm):
+        """Given Neutral state, then next state must be Neutral or FirstGear"""
+        self.auto.step(rpm)
+        state = self.auto.state
+        assert isinstance(state, Neutral) or isinstance(state, FirstGear)
+
+TestAutoFSM = AutoFSMTest.TestCase


### PR DESCRIPTION
Notice that the state machine being tested (`TransmissionSystem`) is
not itself a subclass of hypothesis'
`RuleBasedStateMachine` (`RBSM`). Instead, a separate class
`AutoFSMTest` is the `RBSM` subclass. It creates an instance of and
then exercises the `TransmissionSystem`. `AutoFSMTest` also happens to
be a state machine, but it is used to test a different state machine.